### PR TITLE
[wip] make keyboard compatible with browser

### DIFF
--- a/js/core/keyboard/index.js
+++ b/js/core/keyboard/index.js
@@ -13,5 +13,5 @@
 // limitations under the License.
 
 var EventController = require('event-controller');
-exports.onKeydown = new EventController();
-exports.onKeyup = new EventController();
+exports.onkeydown = new EventController();
+exports.onkeyup = new EventController();

--- a/js/driver/ps2/keyboard.js
+++ b/js/driver/ps2/keyboard.js
@@ -119,18 +119,20 @@ function keyEvent(code, isPressed) {
     }
   }
 
-  var keyinfo = {
+  var event = {
     type: cmd,
     character: character,
-    alt: (statuses.leftalt || statuses.rightalt),
-    shift: statuses.leftshift || statuses.rightshift,
-    ctrl: statuses.leftctrl || statuses.rightctrl
+    altKey: (statuses.leftalt || statuses.rightalt),
+    shiftKey: statuses.leftshift || statuses.rightshift,
+    ctrlKey: statuses.leftctrl || statuses.rightctrl,
+    // TODO: Figure out if this makes sense to support
+    metaKey: false
   };
 
   if (isPressed) {
-    runtime.keyboard.onkeydown.dispatch(keyinfo);
+    runtime.keyboard.onkeydown.dispatch(event);
   } else {
-    runtime.keyboard.onkeyup.dispatch(keyinfo);
+    runtime.keyboard.onkeyup.dispatch(event);
   }
 }
 

--- a/js/driver/ps2/keyboard.js
+++ b/js/driver/ps2/keyboard.js
@@ -119,6 +119,8 @@ function keyEvent(code, isPressed) {
     }
   }
 
+  var keyCode = character.charCodeAt(0);
+
   var event = {
     type: cmd,
     character: character,
@@ -126,7 +128,9 @@ function keyEvent(code, isPressed) {
     shiftKey: statuses.leftshift || statuses.rightshift,
     ctrlKey: statuses.leftctrl || statuses.rightctrl,
     // TODO: Figure out if this makes sense to support
-    metaKey: false
+    metaKey: false,
+    keyCode: keyCode,
+    which: keyCode
   };
 
   if (isPressed) {

--- a/js/driver/ps2/keyboard.js
+++ b/js/driver/ps2/keyboard.js
@@ -128,9 +128,9 @@ function keyEvent(code, isPressed) {
   };
 
   if (isPressed) {
-    runtime.keyboard.onKeydown.dispatch(keyinfo);
+    runtime.keyboard.onkeydown.dispatch(keyinfo);
   } else {
-    runtime.keyboard.onKeyup.dispatch(keyinfo);
+    runtime.keyboard.onkeyup.dispatch(keyinfo);
   }
 }
 

--- a/js/service/shell/input-box.js
+++ b/js/service/shell/input-box.js
@@ -158,7 +158,7 @@ function setInputBox(text) {
 drawPrompt();
 drawCursor();
 
-runtime.keyboard.onKeydown.add(function(keyinfo) {
+runtime.keyboard.onkeydown.add(function(keyinfo) {
   if (!inputEnabled) {
     return;
   }


### PR DESCRIPTION
- [x] keyboard.on{Keydown, Keyup} -> keyboard.on{keydown, keyup}
- [ ] change event to be the same as https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent