### PR TITLE
Fix issue #53: Not printing ints and etc

### DIFF
--- a/js/core/tty/terminal.js
+++ b/js/core/tty/terminal.js
@@ -35,6 +35,9 @@ refresh();
 exports.color = vga.color;
 
 exports.print = function(text, repeat, fg, bg) {
+  // fix issue #53 where non-strings (ints, etc...) would not get printed
+  text = String(text);
+  
   repeat = repeat || 1;
 
   if (typeof fg === 'undefined') {


### PR DESCRIPTION
Resolves minor problem where non-string values for text in exports.print would not be printed. Fixes #53