### PR TITLE
Fix "AssertionError: false == true"

### DIFF
--- a/js/component/dns-client/index.js
+++ b/js/component/dns-client/index.js
@@ -92,6 +92,11 @@ DNSClient.prototype.resolve = function(domain, opts, cb) {
   assert(this instanceof DNSClient);
   assert(typeutils.isString(domain));
   assert(typeutils.isFunction(cb));
+  
+  // if domain contains http:// or ftp:// or https:// (etc...), remove it.
+  if (domain.indexOf("://") !== -1) {
+    domain = domain.match(/[a-z]\:\/\/([a-zA-Z\-\.1-9]+)\/[a-zA-Z\-\.1-9\_\/]+/)[1];
+  }
 
   this._sendQuery(domain);
   this._requests.push({


### PR DESCRIPTION
This fix prevents an AssertionError when given a domain including the URL schema (http...).
Note: The regex used returns the domain like "www.example.com", i'm sure this is what it expects.