### PR TITLE
Add run command and get features

### DIFF
--- a/js/core/index.js
+++ b/js/core/index.js
@@ -37,7 +37,7 @@ function Runtime() {
       resources.acpi.enterSleepState(5);
     }
   };
-  this.stdio = stdio;
+  this.stdio = new stdio();
 }
 
 global.runtime = module.exports = new Runtime();

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -20,6 +20,7 @@ var keyboard = require('./keyboard');
 var ps2 = require('./ps2');
 var pci = require('./pci');
 var net = require('./net');
+var stdio = require('./stdio');
 
 function Runtime() {
   this.tty = tty;
@@ -36,6 +37,7 @@ function Runtime() {
       resources.acpi.enterSleepState(5);
     }
   };
+  this.stdio = stdio;
 }
 
 global.runtime = module.exports = new Runtime();

--- a/js/core/stdio/index.js
+++ b/js/core/stdio/index.js
@@ -1,0 +1,30 @@
+// Copyright 2014-2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var stdout = require('./stdout');
+var stdin = require('./stdin');
+
+var combined = {};
+
+for (var obj in stdin) {
+  combined[obj] = stdin[obj];
+}
+
+for (var obj2 in stdout) {
+  combined[obj2] = stdout[obj2];
+}
+
+exports = combined;

--- a/js/core/stdio/index.js
+++ b/js/core/stdio/index.js
@@ -25,3 +25,5 @@ function IO() {
   // stdin
   this.readline = stdin.readline;
 }
+
+module.exports = IO;

--- a/js/core/stdio/index.js
+++ b/js/core/stdio/index.js
@@ -17,10 +17,11 @@
 var stdout = require('./stdout');
 var stdin = require('./stdin');
 
-for (var obj in stdin) {
-  exports[obj] = stdin[obj];
-}
+function IO() {
+  // stdout
+  this.write = stdout.write;
+  this.writeline = stdout.write;
 
-for (var obj2 in stdout) {
-  exports[obj2] = stdout[obj2];
+  // stdin
+  this.readline = stdin.readline;
 }

--- a/js/core/stdio/index.js
+++ b/js/core/stdio/index.js
@@ -17,14 +17,10 @@
 var stdout = require('./stdout');
 var stdin = require('./stdin');
 
-var combined = {};
-
 for (var obj in stdin) {
-  combined[obj] = stdin[obj];
+  exports[obj] = stdin[obj];
 }
 
 for (var obj2 in stdout) {
-  combined[obj2] = stdout[obj2];
+  exports[obj2] = stdout[obj2];
 }
-
-exports = combined;

--- a/js/core/stdio/stdin.js
+++ b/js/core/stdio/stdin.js
@@ -1,0 +1,19 @@
+// Copyright 2014-2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+exports.readline = function(cb) {
+  runtime.tty.get(cb);
+}

--- a/js/core/stdio/stdout.js
+++ b/js/core/stdio/stdout.js
@@ -1,0 +1,23 @@
+// Copyright 2014-2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+exports.write = function(text, fg, bg) {
+  runtime.tty.print(text, 1, fg, bg);
+}
+
+exports.writeline = function(text, fg, bg) {
+  runtime.tty.print(text + '\n', 1, fg, bg);
+}

--- a/js/core/tty/readline.js
+++ b/js/core/tty/readline.js
@@ -13,63 +13,8 @@
 // limitations under the License.
 
 'use strict';
-var vga = require('./vga');
-var EventController = require('event-controller');
-var buffer = vga.allocBuffer();
-buffer.clear(vga.color.BLACK);
 
-var posCurrent = 0;
-var w = vga.WIDTH;
-var h = vga.HEIGHT;
-
-function refresh() {
-  vga.draw(buffer);
-}
-
-function scrollUp() {
-  buffer.scrollUp(vga.color.BLACK);
-  posCurrent -= w;
-}
-
-refresh();
-
-exports.color = vga.color;
-
-exports.print = function(text, repeat, fg, bg) {
-  // fix issue #53 where non-strings (ints, etc...) would not get printed
-  text = String(text);
-
-  repeat = repeat || 1;
-
-  if (typeof fg === 'undefined') {
-    fg = vga.color.WHITE;
-  }
-
-  if (typeof bg === 'undefined') {
-    bg = vga.color.BLACK;
-  }
-
-  for (var j = 0; j < repeat; ++j) {
-    for (var i = 0, l = text.length; i < l; ++i) {
-      var c = text.charAt(i);
-      if ('\n' === c) {
-        posCurrent -= posCurrent % w - w;
-        if (posCurrent >= w * h) {
-          scrollUp();
-        }
-      } else {
-        if (posCurrent >= w * h) {
-          scrollUp();
-        }
-        buffer.setOffset(posCurrent++, c, fg, bg);
-      }
-    }
-  }
-
-  refresh();
-};
-
-exports.get = function() {
+exports.get = function(cb) {
   var tty = runtime.tty;
   var inputText = '';
   var inputPosition = 0;
@@ -78,7 +23,6 @@ exports.get = function() {
   var done = false;
   var inputEnabled = true;
   var endresult = '';
-  var controller = new EventController();
 
   function drawCursor() {
     var char = ' ';
@@ -158,10 +102,14 @@ exports.get = function() {
       history.splice(1, 0, result);
 
       runtime.keyboard.onKeydown.remove(addinput);
-      controller.dispatch(result);
+      if (cb) {
+        cb(result);
+      }
     } else {
       runtime.keyboard.onKeydown.remove(addinput);
-      controller.dispatch(result);
+      if (cb) {
+        cb(result);
+      }
     }
   }
 
@@ -206,28 +154,4 @@ exports.get = function() {
   runtime.keyboard.onKeydown.add(addinput);
 
   drawCursor();
-
-  return controller;
 }
-
-exports.moveOffset = function(offset) {
-  offset = offset | 0;
-  var newPos = posCurrent + offset;
-  if (newPos < 0) {
-    newPos = 0;
-  }
-
-  if (newPos >= w * h) {
-    newPos = w * h - 1;
-  }
-
-  posCurrent = newPos;
-};
-
-exports.moveTo = function(x, y) {
-  if (x < 0) { x = 0; }
-  if (x >= w) { x = w - 1; }
-  if (y < 0) { y = 0; }
-  if (y >= h) { y = h - 1; }
-  posCurrent = y * w + x;
-};

--- a/js/core/tty/terminal.js
+++ b/js/core/tty/terminal.js
@@ -14,6 +14,7 @@
 
 'use strict';
 var vga = require('./vga');
+var EventController = require('event-controller');
 var buffer = vga.allocBuffer();
 buffer.clear(vga.color.BLACK);
 
@@ -37,7 +38,7 @@ exports.color = vga.color;
 exports.print = function(text, repeat, fg, bg) {
   // fix issue #53 where non-strings (ints, etc...) would not get printed
   text = String(text);
-  
+
   repeat = repeat || 1;
 
   if (typeof fg === 'undefined') {
@@ -67,6 +68,147 @@ exports.print = function(text, repeat, fg, bg) {
 
   refresh();
 };
+
+exports.get = function() {
+  var tty = runtime.tty;
+  var inputText = '';
+  var inputPosition = 0;
+  var history = [''];
+  var historyPosition = 0;
+  var done = false;
+  var inputEnabled = true;
+  var endresult = '';
+  var controller = new EventController();
+
+  function drawCursor() {
+    var char = ' ';
+    if (inputPosition < inputText.length) {
+      char = inputText[inputPosition];
+    }
+
+    tty.print(char, 1, tty.color.WHITE, tty.color.LIGHTGREEN);
+    tty.moveOffset(-1);
+  }
+
+  function removeCursor() {
+    var char = ' ';
+    if (inputPosition < inputText.length) {
+      char = inputText[inputPosition];
+    }
+
+    tty.print(char, 1, tty.color.WHITE, tty.color.BLACK);
+    tty.moveOffset(-1);
+  }
+
+  function putChar(char) {
+    removeCursor();
+    if (inputPosition >= inputText.length) {
+      inputText += char;
+      tty.print(char);
+    } else {
+      var rightSide = inputText.slice(inputPosition);
+      inputText = inputText.slice(0, inputPosition) + char + rightSide;
+      tty.print(char);
+      for (var i = 0; i < rightSide.length; ++i) {
+        tty.print(rightSide[i]);
+      }
+      tty.moveOffset(-rightSide.length);
+    }
+    ++inputPosition;
+    drawCursor();
+  }
+
+  function removeChar() {
+    if (inputPosition > 0) {
+      removeCursor();
+      if (inputPosition >= inputText.length) {
+        inputText = inputText.slice(0, -1);
+        tty.moveOffset(-1);
+      } else {
+        var rightSide = inputText.slice(inputPosition);
+        inputText = inputText.slice(0, inputPosition - 1) + rightSide;
+        tty.moveOffset(-1);
+        for (var i = 0; i < rightSide.length; ++i) {
+          tty.print(rightSide[i]);
+        }
+        tty.print(' ');
+        tty.moveOffset(-rightSide.length - 1);
+      }
+      --inputPosition;
+      drawCursor();
+    }
+  }
+
+  function newLine() {
+    var text = inputText;
+    inputEnabled = false;
+    historyPosition = 0;
+    removeCursor();
+    tty.print('\n');
+
+    inputText = '';
+    inputPosition = 0;
+
+    var result = text.trim();
+    if (result.length > 0) {
+      var currentIndex = history.indexOf(result);
+      if (currentIndex >= 0) {
+        history.splice(currentIndex, 1);
+      }
+      history.splice(1, 0, result);
+
+      runtime.keyboard.onKeydown.remove(addinput);
+      controller.dispatch(result);
+    } else {
+      runtime.keyboard.onKeydown.remove(addinput);
+      controller.dispatch(result);
+    }
+  }
+
+  function addinput(keyinfo) {
+    if (!inputEnabled) {
+      return;
+    }
+
+    switch (keyinfo.type) {
+    case 'kpup':
+      if (historyPosition < history.length - 1) {
+        setInputBox(history[++historyPosition]);
+      }
+      break;
+    case 'kpdown':
+      if (historyPosition > 0) {
+        setInputBox(history[--historyPosition]);
+      }
+      break;
+    case 'kpleft':
+      historyPosition = 0;
+      moveCursorLeft();
+      break;
+    case 'kpright':
+      historyPosition = 0;
+      moveCursorRight();
+      break;
+    case 'character':
+      historyPosition = 0;
+      putChar(keyinfo.character);
+      break;
+    case 'backspace':
+      historyPosition = 0;
+      removeChar();
+      break;
+    case 'enter':
+      newLine();
+      break;
+    }
+  }
+
+  runtime.keyboard.onKeydown.add(addinput);
+
+  drawCursor();
+
+  return controller;
+}
 
 exports.moveOffset = function(offset) {
   offset = offset | 0;

--- a/js/core/tty/terminal.js
+++ b/js/core/tty/terminal.js
@@ -1,0 +1,93 @@
+// Copyright 2014-2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+var vga = require('./vga');
+var readline = require('./readline');
+var buffer = vga.allocBuffer();
+buffer.clear(vga.color.BLACK);
+
+var posCurrent = 0;
+var w = vga.WIDTH;
+var h = vga.HEIGHT;
+
+function refresh() {
+  vga.draw(buffer);
+}
+
+function scrollUp() {
+  buffer.scrollUp(vga.color.BLACK);
+  posCurrent -= w;
+}
+
+refresh();
+
+exports.color = vga.color;
+exports.get = readline.get;
+
+exports.print = function(text, repeat, fg, bg) {
+  // fix issue #53 where non-strings (ints, etc...) would not get printed
+  text = String(text);
+
+  repeat = repeat || 1;
+
+  if (typeof fg === 'undefined') {
+    fg = vga.color.WHITE;
+  }
+
+  if (typeof bg === 'undefined') {
+    bg = vga.color.BLACK;
+  }
+
+  for (var j = 0; j < repeat; ++j) {
+    for (var i = 0, l = text.length; i < l; ++i) {
+      var c = text.charAt(i);
+      if ('\n' === c) {
+        posCurrent -= posCurrent % w - w;
+        if (posCurrent >= w * h) {
+          scrollUp();
+        }
+      } else {
+        if (posCurrent >= w * h) {
+          scrollUp();
+        }
+        buffer.setOffset(posCurrent++, c, fg, bg);
+      }
+    }
+  }
+
+  refresh();
+};
+
+exports.moveOffset = function(offset) {
+  offset = offset | 0;
+  var newPos = posCurrent + offset;
+  if (newPos < 0) {
+    newPos = 0;
+  }
+
+  if (newPos >= w * h) {
+    newPos = w * h - 1;
+  }
+
+  posCurrent = newPos;
+};
+
+exports.moveTo = function(x, y) {
+  if (x < 0) { x = 0; }
+  if (x >= w) { x = w - 1; }
+  if (y < 0) { y = 0; }
+  if (y >= h) { y = h - 1; }
+  posCurrent = y * w + x;
+};

--- a/js/index.js
+++ b/js/index.js
@@ -34,8 +34,8 @@ runtime.dns = require('./service/dns-resolver');
 runtime.debug = isDebug;
 
 // Example shell command
-runtime.shell.setCommand('1', function(args, cb) {
-  runtime.tty.print('OK.\n');
+runtime.shell.setCommand('1', function(args, stdio, cb) {
+  stdio.writeline('OK.');
   runtime.dns.resolve('www.google.com', {}, function(err, data) {
     if (err) return cb();
     console.log(JSON.stringify(data));

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimejs",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Core runtime.js library",
   "main": "index.js",
   "scripts": {

--- a/js/service/shell/captureio.js
+++ b/js/service/shell/captureio.js
@@ -17,13 +17,23 @@
 var events = require('events');
 exports.events = new events.EventEmitter();
 exports.io = {};
+exports.io.acceptInput = false;
+
+exports.events.on('stdin', function(text) {
+  if (exports.io.acceptInput) {
+    exports.events.callback(text);
+    exports.io.acceptInput = false;
+  }
+});
 
 exports.io.readline = function(cb) {
-  runtime.tty.get(cb);
+  exports.events.acceptInput = true;
+  exports.events.callback = cb;
+  exports.events.emit('feed');
 }
 
 exports.io.write = function(text, fg, bg) {
-  exports.events.emit('data', {
+  exports.events.emit('stdout', {
     text: text,
     color: {
       fg: fg,
@@ -33,7 +43,7 @@ exports.io.write = function(text, fg, bg) {
 }
 
 exports.io.writeline = function(text, fg, bg) {
-  exports.events.emit('data', {
+  exports.events.emit('stdout', {
     text: text + '\n',
     color: {
       fg: fg,

--- a/js/service/shell/captureio.js
+++ b/js/service/shell/captureio.js
@@ -1,0 +1,42 @@
+// Copyright 2014-2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var events = require('events');
+exports.events = new events.EventEmitter();
+
+exports.io.readline = function(cb) {
+  runtime.tty.get(cb);
+}
+
+exports.io.write = function(text, fg, bg) {
+  exports.events.emit('data', {
+    text: text,
+    color: {
+      fg: fg,
+      bg: bg
+    }
+  });
+}
+
+exports.io.writeline = function(text, fg, bg) {
+  exports.events.emit('data', {
+    text: text + '\n',
+    color: {
+      fg: fg,
+      bg: bg
+    }
+  });
+}

--- a/js/service/shell/captureio.js
+++ b/js/service/shell/captureio.js
@@ -16,6 +16,7 @@
 
 var events = require('events');
 exports.events = new events.EventEmitter();
+exports.io = {};
 
 exports.io.readline = function(cb) {
   runtime.tty.get(cb);

--- a/js/service/shell/index.js
+++ b/js/service/shell/index.js
@@ -45,11 +45,18 @@ exports.setCommand = function(name, cb) {
   commands.set(name, cb);
 };
 
-exports.runCommand = function(name, args) {
+exports.runCommand = function(name, args, cb) {
+  var capture = require('./captureio.js');
+
   assert(typeutils.isString(name));
 
   args = args || "";
 
-  commands.get(name)(args, inputBox.done);
-  return;
+  commands.get(name)(args, capture.io, inputBox.done);
+
+  if (cb) {
+    cb(capture.events);
+  }
+
+  return capture.events;
 }

--- a/js/service/shell/index.js
+++ b/js/service/shell/index.js
@@ -32,7 +32,7 @@ inputBox.onInput.add(function(text, done) {
   }
 
   if (commands.has(name)) {
-    return commands.get(name)(args, done);
+    return commands.get(name)(args, runtime.stdio, done);
   }
 
   tty.print('Command "' + name + '" not found.\n', 1, tty.color.LIGHTRED);

--- a/js/service/shell/index.js
+++ b/js/service/shell/index.js
@@ -52,9 +52,10 @@ exports.runCommand = function(name, args, cb) {
 
   args = args || "";
 
-  commands.get(name)(args, capture.io, inputBox.done);
+  commands.get(name)(args, capture.io, function() { capture.events.emit('end'); });
 
   if (cb) {
+    capture.events.redrawPrompt = inputBox.done;
     cb(capture.events);
   }
 

--- a/js/service/shell/index.js
+++ b/js/service/shell/index.js
@@ -44,3 +44,12 @@ exports.setCommand = function(name, cb) {
   assert(typeutils.isFunction(cb));
   commands.set(name, cb);
 };
+
+exports.runCommand = function(name, args) {
+  assert(typeutils.isString(name));
+
+  args = args || "";
+
+  commands.get(name)(args, inputBox.done);
+  return;
+}

--- a/js/service/shell/index.js.rej
+++ b/js/service/shell/index.js.rej
@@ -1,0 +1,18 @@
+***************
+*** 44,46 ****
+    assert(typeutils.isFunction(cb));
+    commands.set(name, cb);
+  };
+--- 44,55 ----
+    assert(typeutils.isFunction(cb));
+    commands.set(name, cb);
+  };
++ 
++ exports.runCommand = function(name, args) {
++   assert(typeutils.isString(name));
++ 
++   args = args || "";
++ 
++   commands.get(name)(args, inputBox.done);
++   return;
++ }

--- a/js/service/shell/input-box.js
+++ b/js/service/shell/input-box.js
@@ -198,3 +198,9 @@ runtime.keyboard.onKeydown.add(function(keyinfo) {
 });
 
 exports.onInput = onInput;
+exports.done = function() {
+  tty.print('\n');
+  inputEnabled = true;
+  drawPrompt();
+  drawCursor();
+};

--- a/js/service/shell/input-box.js.rej
+++ b/js/service/shell/input-box.js.rej
@@ -1,0 +1,15 @@
+***************
+*** 198,200 ****
+  });
+  
+  exports.onInput = onInput;
+--- 198,206 ----
+  });
+  
+  exports.onInput = onInput;
++ exports.done = function() {
++   tty.print('\n');
++   inputEnabled = true;
++   drawPrompt();
++   drawCursor();
++ };


### PR DESCRIPTION
This adds a run commands feature to `runtime.shell`. If you get an error with the `args` parameter, add a space at the beginning of the string.
Usage:
```javascript
runtime.shell.runCommand(commandName, [arguments]);
// Example:
runtime.shell.runCommand("echo", " hey");
```

UPDATE:
I just added a `get` function to `runtime.tty`, which allows you to get text from the user easily.
It returns an `EventController` object that you can listen to.
Usage:
```javascript
var foo = runtime.tty.get();
foo.add(function(text) {
  runtime.tty.print(text);
  // or whatever you want to do with `text`
});
```