### PR TITLE
Fix args in runtime.shell.runCommand()

### DIFF
--- a/js/service/shell/index.js
+++ b/js/service/shell/index.js
@@ -36,7 +36,7 @@ exports.runCommand = function(name, args, done) {
     opts.args = args;
   } else {
     opts = args;
-    opts.args = [];
+    opts.args = opts.args || [];
   }
 
   var stringargs = opts.args.join(' ');


### PR DESCRIPTION
Just a simple fix that will resolves and closes #67. Changes `opts.args = []` to `opts.args = opts.args || []`.