### PR TITLE
ICMP protocol and ping

### DIFF
--- a/js/core/net/icmp-header.js
+++ b/js/core/net/icmp-header.js
@@ -17,6 +17,9 @@ var u8view = require('u8-view');
 
 exports.headerLength = 8;
 
+exports.ICMP_TYPE_ECHO_REPLY = 0;
+exports.ICMP_TYPE_ECHO_REQUEST = 8;
+
 exports.getType = function(u8, headerOffset) {
   return u8[headerOffset];
 };

--- a/js/core/net/icmp-header.js
+++ b/js/core/net/icmp-header.js
@@ -1,0 +1,48 @@
+// Copyright 2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+var u8view = require('u8-view');
+
+exports.headerLength = 8;
+
+exports.getType = function(u8, headerOffset) {
+  return u8[headerOffset];
+};
+
+exports.getCode = function(u8, headerOffset) {
+  return u8[headerOffset + 1];
+};
+
+exports.getEchoRequestIdentifier = function(u8, headerOffset) {
+  return u8view.getUint16BE(u8, headerOffset + 4);
+};
+
+exports.getEchoRequestSequence = function(u8, headerOffset) {
+  return u8view.getUint16BE(u8, headerOffset + 6);
+};
+
+exports.write = function(u8, headerOffset, type, code, headerValue) {
+  u8[headerOffset] = type;
+  u8[headerOffset + 1] = code;
+  u8view.setUint32BE(u8, headerOffset + 4, headerValue);
+};
+
+exports.writeChecksum = function(u8, headerOffset, checksum) {
+  u8view.setUint16BE(u8, headerOffset + 2, checksum);
+};
+
+exports.headerValueEcho = function(id, seq) {
+  return (((id & 0xffff) << 16) | (seq & 0xffff)) >>> 0;
+};

--- a/js/core/net/icmp-transmit.js
+++ b/js/core/net/icmp-transmit.js
@@ -1,0 +1,40 @@
+// Copyright 2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+var checksum = require('./checksum');
+var ethernet = require('./ethernet');
+var ip4header = require('./ip4-header');
+var icmpHeader = require('./icmp-header');
+var route = require('./route');
+
+module.exports = function(intf, destIP, viaIP, type, code, headerValue, u8data) {
+  var ipOffset = intf.bufferDataOffset + ethernet.headerLength;
+  var icmpOffset = ipOffset + ip4header.minHeaderLength;
+  var headerLength = icmpOffset + icmpHeader.headerLength;
+  var u8headers = new Uint8Array(headerLength);
+
+  var srcIP = intf.ipAddr;
+
+  ip4header.write(u8headers, ipOffset, ip4header.PROTOCOL_ICMP, srcIP, destIP,
+    ip4header.minHeaderLength + icmpHeader.headerLength + u8data.length);
+  icmpHeader.write(u8headers, icmpOffset, type, code, headerValue);
+
+  var ckHeader = checksum.buffer(u8headers, icmpOffset, icmpHeader.headerLength);
+  var ckData = u8data ? checksum.buffer(u8data, 0, u8data.length) : 0;
+  var ck = checksum.result(ckHeader + ckData);
+  icmpHeader.writeChecksum(u8headers, icmpOffset, ck);
+
+  intf.sendIP4(viaIP || destIP, u8headers, u8data);
+};

--- a/js/core/net/icmp.js
+++ b/js/core/net/icmp.js
@@ -14,6 +14,41 @@
 
 'use strict';
 
-exports.receive = function(intf, u8, headerOffset) {
+var icmpHeader = require('./icmp-header');
+var icmpTransmit = require('./icmp-transmit');
+var route = require('./route');
+
+var ICMP_TYPE_ECHO_REPLY = 0;
+var ICMP_TYPE_ECHO_REQUEST = 8;
+
+function handleEchoRequest(intf, srcIP, u8, headerOffset) {
+  if (srcIP.isBroadcast() || srcIP.isAny()) {
+    return;
+  }
+
+  var routingEntry = route.lookup(srcIP);
+  if (!routingEntry) {
+    debug('[ICMP] no route for ICMP reply to ' + srcIP);
+    return;
+  }
+
+  var viaIP = routingEntry.gateway;
+  var id = icmpHeader.getEchoRequestIdentifier(u8, headerOffset);
+  var seq = icmpHeader.getEchoRequestSequence(u8, headerOffset);
+
+  icmpTransmit(intf, srcIP, viaIP, ICMP_TYPE_ECHO_REPLY, 0,
+               icmpHeader.headerValueEcho(id, seq),
+               u8.subarray(headerOffset + icmpHeader.headerLength));
+}
+
+exports.receive = function(intf, srcIP, destIP, u8, headerOffset) {
   debug('recv ICMP over IP4');
+
+  var type = icmpHeader.getType(u8, headerOffset);
+  var code = icmpHeader.getCode(u8, headerOffset);
+
+  if (type === ICMP_TYPE_ECHO_REQUEST) {
+    handleEchoRequest(intf, srcIP, u8, headerOffset);
+    return;
+  }
 };

--- a/js/core/net/index.js
+++ b/js/core/net/index.js
@@ -24,6 +24,7 @@ var IP4Address = require('./ip4-address');
 var loopback = require('./loopback');
 var TCPSocket = require('./tcp-socket');
 var TCPServerSocket = require('./tcp-server-socket');
+var Ping = require('./ping');
 var stat = require('./net-stat');
 
 var onInterfaceAdded = new EventController();
@@ -46,6 +47,7 @@ exports.UDPSocket = UDPSocket;
 exports.IP4Address = IP4Address;
 exports.MACAddress = MACAddress;
 exports.Interface = Interface;
+exports.Ping = Ping;
 exports.route = route;
 exports.stat = stat;
 

--- a/js/core/net/ip4-address.js
+++ b/js/core/net/ip4-address.js
@@ -58,6 +58,10 @@ IP4Address.BROADCAST = new IP4Address(255, 255, 255, 255);
 IP4Address.LOOPBACK = new IP4Address(127, 0, 0, 1);
 
 IP4Address.parse = function(str) {
+  if (str instanceof IP4Address) {
+    return str;
+  }
+
   if ('string' !== typeof str) {
     return null;
   }

--- a/js/core/net/ip4.js
+++ b/js/core/net/ip4.js
@@ -27,7 +27,7 @@ exports.receive = function(intf, u8, headerOffset) {
   var nextOffset = headerOffset + headerLength;
 
   switch (protocolId) {
-  case 0x01: return icmp.receive(intf, u8, nextOffset);
+  case 0x01: return icmp.receive(intf, srcIP, destIP, u8, nextOffset);
   case 0x06: return tcp.receive(intf, srcIP, destIP, u8, nextOffset);
   case 0x11: return udp.receive(intf, srcIP, destIP, u8, nextOffset);
   }

--- a/js/core/net/ping.js
+++ b/js/core/net/ping.js
@@ -14,12 +14,93 @@
 
 'use strict';
 
+var assertError = require('assert-error');
 var IP4Address = require('./ip4-address');
+var icmpTransmit = require('./icmp-transmit');
+var icmpHeader = require('./icmp-header');
+var route = require('./route');
+var netError = require('./net-error');
+var pingListeners = new Map();
+
+function createPingBuffer(size) {
+  var u8 = new Uint8Array(size);
+  for (var i = 0; i < size; ++i) {
+    u8[i] = 0x61 + (i % 26); // ASCII a-z
+  }
+  return u8;
+}
+
+var nextPingId = 1;
+var defaultPingData = createPingBuffer(56);
 
 class Ping {
   constructor() {
+    this._pingId = (nextPingId++) & 0xffff;
+    this._nextSeq = 0;
+    this._data = defaultPingData;
+    this.onreply = null;
   }
 
+  /**
+   * Send ICMP echo request (ping) to specified address. Returns request
+   * sequence number.
+   */
   send(ip) {
+    var destIP = IP4Address.parse(ip);
+    assertError(destIP instanceof IP4Address, netError.E_IPADDRESS_EXPECTED);
+
+    var seq = this._nextSeq++;
+    if (this._nextSeq > 0xffff) {
+      this._nextSeq = 0;
+    }
+
+    var routingEntry = route.lookup(destIP);
+    if (!routingEntry) {
+      debug('[ICMP] no route to send ICMP request to ' + destIP);
+      return seq;
+    }
+
+    if (!pingListeners.has(this._pingId)) {
+      pingListeners.set(this._pingId, this);
+    }
+
+    var intf = routingEntry.intf;
+    var viaIP = routingEntry.gateway;
+    icmpTransmit(intf, destIP, viaIP, icmpHeader.ICMP_TYPE_ECHO_REQUEST, 0,
+      icmpHeader.headerValueEcho(this._pingId, seq), this._data);
+
+    return seq;
+  }
+
+  _receive(srcIP, seq, u8, dataOffset) {
+    var dataLength = u8.length - dataOffset;
+    if (dataLength !== this._data.length) {
+      return;
+    }
+
+    for (var i = 0, l = dataLength; i < l; ++i) {
+      if (u8[dataOffset + i] !== this._data[i]) {
+        return;
+      }
+    }
+
+    if (this.onreply) {
+      this.onreply(srcIP, seq);
+    }
+  }
+
+  /**
+   * Stop listening to echo replies.
+   */
+  close() {
+    if (pingListeners.has(this._pingId)) {
+      pingListeners.delete(this._pingId);
+    }
+  }
+
+  static _receiveLookup(pingId) {
+    return pingListeners.get(pingId) || null;
   }
 }
+
+module.exports = Ping;

--- a/js/core/net/ping.js
+++ b/js/core/net/ping.js
@@ -1,0 +1,25 @@
+// Copyright 2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var IP4Address = require('./ip4-address');
+
+class Ping {
+  constructor() {
+  }
+
+  send(ip) {
+  }
+}


### PR DESCRIPTION
ICMP protocol implementation.

- [x] respond to ICMP echo requests (ping)
- [x] runtime.net.Ping interface to be able to send ping requests
- [ ] add tests (going to be added separately)

Notes:
QEMU does not support ICMP in default networking mode

Ping example:
```js
var ping = new runtime.net.Ping();

ping.onreply = function(ip, seq) {
  console.log('ping reply from ' + ip + ' seq=' + seq);
  ping.close(); // stop waiting for more replies and let GC remove ping instance
};

ping.send('192.168.1.1');
```