### PR TITLE
[wip] Tests & tests infrastructure

### DIFF
--- a/.runtimeignore
+++ b/.runtimeignore
@@ -3,12 +3,11 @@
 /node_modules/eslint-plugin-runtime-internal
 /node_modules/runtime-tools
 /node_modules/runtimeify
+/node_modules/runtime-cli
 /node_modules/tape
 /node_modules/eslint-config-runtime
 /test
-tape/
 module-singleton/test-modules/
-test.js
 README.md
 LICENSE.isaac
 LICENSE
@@ -18,6 +17,7 @@ LICENSE
 /tmp
 /scripts
 /testcc
+/test
 /disk
 /docker
 /docs

--- a/js/__loader.js
+++ b/js/__loader.js
@@ -14,292 +14,63 @@
 
 'use strict';
 
-(() => {
-  // from https://github.com/runtimejs/runtime-module-loader/blob/master/index.js
-  class Loader {
-    constructor(existsFileFn, readFileFn, evalScriptFn, builtins = {}, builtinsResolveFrom = '/') {
-      const cache = {};
-      const builtinsResolveFromComponents = builtinsResolveFrom.split('/');
+__SYSCALL.loaderSetupBuiltins({
+  assert: 'assert',
+  events: 'events',
+  buffer: 'buffer',
+  process: './modules/process.js',
+  console: './modules/console.js',
+  constants: 'constants-browserify',
+  fs: './modules/fs.js',
+  os: './modules/os.js',
+  net: './modules/net.js',
+  dns: './modules/dns.js',
+  punycode: 'punycode',
+  querystring: 'querystring-es3',
+  string_decoder: 'string_decoder',
+  path: 'path-browserify',
+  url: 'url',
+  stream: './modules/stream.js',
+  inherits: './modules/inherits.js',
+  sys: 'util/util.js',
+  util: 'util/util.js',
+});
 
-      function throwError(err) {
-        throw err;
-      }
+require('./index');
 
-      function endsWith(str, suffix) {
-        return str.indexOf(suffix, str.length - suffix.length) !== -1;
-      }
+global.process = require('process');
+global.Buffer = require('buffer').Buffer;
 
-      function normalizePath(components) {
-        const r = [];
-        for (const p of components) {
-          if (p === '') {
-            if (r.length === 0) {
-              r.push(p);
-            }
-            continue;
-          }
+const stream = require('stream');
 
-          if (p === '.') {
-            continue;
-          }
-
-          if (p === '..') {
-            if (r.length > 0) {
-              r.pop();
-            } else {
-              return null;
-            }
-          } else {
-            r.push(p);
-          }
-        }
-
-        return r;
-      }
-
-      function loadAsFile(path) {
-        if (existsFileFn(path)) return path;
-        if (existsFileFn(`${path}.js`)) return `${path}.js`;
-        if (existsFileFn(`${path}.json`)) return `${path}.json`;
-        if (existsFileFn(`${path}.node`)) return `${path}.node`;
-
-        return null;
-      }
-
-      function getPackageMain(packageJsonFile) {
-        const json = readFileFn(packageJsonFile);
-        let parsed = null;
-        try {
-          parsed = JSON.parse(json);
-        } catch (e) {
-          throwError(new Error(`package.json '${packageJsonFile}' parse error`));
-        }
-
-        if (parsed.runtime) {
-          if (typeof parsed.runtime === 'string') {
-            return parsed.runtime;
-          }
-          throwError(new Error(`package.json '${packageJsonFile}' runtime field value is invalid`));
-        }
-
-        return parsed.main || 'index.js';
-      }
-
-      function loadAsDirectory(path, ignoreJson) {
-        let mainFile = 'index';
-        let dir = false;
-        if (!ignoreJson && existsFileFn(`${path}/package.json`)) {
-          mainFile = getPackageMain(`${path}/package.json`) || 'index';
-          dir = true;
-        }
-
-        const normalizedPath = normalizePath(path.split('/').concat(mainFile.split('/')));
-        if (!normalizedPath) {
-          return null;
-        }
-
-        const s = normalizedPath.join('/');
-        const res = loadAsFile(s);
-        if (res) {
-          return res;
-        }
-
-        if (dir) {
-          return loadAsDirectory(s, true);
-        }
-
-        return null;
-      }
-
-      function loadNodeModules(dirComponents, parts) {
-        let count = dirComponents.length;
-
-        while (count-- > 0) {
-          let p = dirComponents.slice(0, count + 1);
-          if (p.length === 0) {
-            continue;
-          }
-
-          if (p[p.length - 1] === 'node_modules') {
-            continue;
-          }
-
-          p.push('node_modules');
-          p = p.concat(parts);
-
-          const normalizedPath = normalizePath(p);
-          if (!normalizedPath) {
-            continue;
-          }
-
-          const s = normalizedPath.join('/');
-          const loadedPath = loadAsFile(s) || loadAsDirectory(s, false) || null;
-          if (loadedPath) {
-            return loadedPath;
-          }
-        }
-
-        return null;
-      }
-
-      function resolve(module, pathOpt = '') {
-        let path = String(pathOpt);
-
-        let resolveFrom = module.dirComponents;
-
-        if (Object.prototype.hasOwnProperty.call(builtins, path)) {
-          path = builtins[path];
-          resolveFrom = builtinsResolveFromComponents;
-        }
-
-        const pathComponents = path.split('/');
-        const firstPathComponent = pathComponents[0];
-
-        // starts with ./ ../  or /
-        if (firstPathComponent === '.' ||
-          firstPathComponent === '..' ||
-          firstPathComponent === '') {
-          const combinedPathComponents = (firstPathComponent === '') ?
-            pathComponents :
-            resolveFrom.concat(pathComponents);
-
-          const normalizedPath = normalizePath(combinedPathComponents);
-          if (!normalizedPath) {
-            return null;
-          }
-
-          const pathStr = normalizedPath.join('/');
-          const loadedPath = loadAsFile(pathStr) || loadAsDirectory(pathStr, false) || null;
-          return loadedPath;
-        }
-
-        return loadNodeModules(resolveFrom, pathComponents);
-      }
-
-      class Module {
-        constructor(pathComponents) {
-          this.dirComponents = pathComponents.slice(0, -1);
-          this.pathComponents = pathComponents;
-          this.filename = pathComponents.join('/');
-          this.dirname = this.dirComponents.length > 1 ? this.dirComponents.join('/') : '/';
-          this.exports = {};
-        }
-        require(path) {
-          let module = this;
-          const resolvedPath = resolve(module, path);
-          if (!resolvedPath) {
-            throwError(new Error(`Cannot resolve module '${path}' from '${module.filename}'`));
-          }
-
-          // eval file
-          const pathComponents = resolvedPath.split('/');
-          const displayPath = resolvedPath;
-          const cacheKey = pathComponents.join('/');
-          if (cache[cacheKey]) {
-            return cache[cacheKey].exports;
-          }
-
-          const currentModule = global.module;
-          module = new Module(pathComponents);
-          cache[cacheKey] = module;
-          global.module = module;
-
-          if (endsWith(resolvedPath, '.node')) {
-            throwError(new Error(`Native Node.js modules are not supported '${resolvedPath}'`));
-          }
-
-          const content = readFileFn(resolvedPath);
-          if (!content) throwError(new Error(`Cannot load module '${resolvedPath}'`));
-
-          if (endsWith(resolvedPath, '.json')) {
-            module.exports = JSON.parse(content);
-          } else {
-            /* eslint-disable max-len */
-            evalScriptFn(
-              `((require,exports,module,__filename,__dirname) => {${content}})(((m) => {return function(path){return m.require(path)}})(global.module),global.module.exports,global.module,global.module.filename,global.module.dirname)`,
-              displayPath);
-            /* eslint-enable max-len */
-          }
-
-          global.module = currentModule;
-          return module.exports;
-        }
-      }
-
-      this.require = (path) => {
-        const rootModule = new Module(['', '']);
-        global.module = rootModule;
-        return rootModule.require(path);
-      };
-    }
+class StdoutStream extends stream.Writable {
+  _write(chunk, encoding, callback) {
+    __SYSCALL.write(String(chunk));
+    callback();
   }
-  // end
+}
+class StderrStream extends stream.Writable {
+  _write(chunk, encoding, callback) {
+    __SYSCALL.write(String(chunk));
+    callback();
+  }
+}
+class TermoutStream extends stream.Writable {
+  _write(chunk, encoding, callback) {
+    runtime.stdio.defaultStdio.write(String(chunk));
+    callback();
+  }
+}
+class TermerrStream extends stream.Writable {
+  _write(chunk, encoding, callback) {
+    runtime.stdio.defaultStdio.writeError(String(chunk));
+    callback();
+  }
+}
 
-  const files = {};
-  for (const file of __SYSCALL.initrdListFiles()) {
-    files[file] = true;
-  }
+process.stdout = new StdoutStream();
+process.stderr = new StderrStream();
+process.termout = new TermoutStream();
+process.termerr = new TermerrStream();
 
-  function fileExists(path) {
-    return !!files[path];
-  }
-
-  const runtimePackagePath = __SYSCALL.initrdGetKernelIndex().split('/').slice(0, -1).join('/');
-  const loader = new Loader(fileExists, __SYSCALL.initrdReadFile, __SYSCALL.eval, {
-    assert: 'assert',
-    events: 'events',
-    buffer: 'buffer',
-    process: './modules/process.js',
-    console: './modules/console.js',
-    constants: 'constants-browserify',
-    fs: './modules/fs.js',
-    os: './modules/os.js',
-    net: './modules/net.js',
-    dns: './modules/dns.js',
-    punycode: 'punycode',
-    querystring: 'querystring-es3',
-    string_decoder: 'string_decoder',
-    path: 'path-browserify',
-    url: 'url',
-    stream: './modules/stream.js',
-    inherits: './modules/inherits.js',
-    sys: 'util/util.js',
-    util: 'util/util.js',
-  }, runtimePackagePath);
-
-  loader.require(`${runtimePackagePath}/index.js`);
-
-  global.process = loader.require('process');
-  global.Buffer = loader.require('buffer').Buffer;
-  const stream = loader.require('stream');
-  class StdoutStream extends stream.Writable {
-    _write(chunk, encoding, callback) {
-      __SYSCALL.write(String(chunk));
-      callback();
-    }
-  }
-  class StderrStream extends stream.Writable {
-    _write(chunk, encoding, callback) {
-      __SYSCALL.write(String(chunk));
-      callback();
-    }
-  }
-  class TermoutStream extends stream.Writable {
-    _write(chunk, encoding, callback) {
-      runtime.stdio.defaultStdio.write(String(chunk));
-      callback();
-    }
-  }
-  class TermerrStream extends stream.Writable {
-    _write(chunk, encoding, callback) {
-      runtime.stdio.defaultStdio.writeError(String(chunk));
-      callback();
-    }
-  }
-  process.stdout = new StdoutStream();
-  process.stderr = new StderrStream();
-  process.termout = new TermoutStream();
-  process.termerr = new TermerrStream();
-  loader.require('console');
-  loader.require('/');
-})();
+require('console');

--- a/src/kernel/engines.h
+++ b/src/kernel/engines.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <string.h>
 #include <json11.hpp>
+#include <kernel/js/loaderjs.h>
 
 namespace rt {
 
@@ -100,16 +101,9 @@ public:
     RT_ASSERT(first_engine);
     ResourceHandle<EngineThread> st = first_engine->threads().Create(ThreadType::DEFAULT);
 
-    const char* filename = GLOBAL_initrd()->runtime_index_name();
-    InitrdFile startup_file = GLOBAL_initrd()->Get(filename);
-    if (startup_file.IsEmpty()) {
-      printf("Unable to load %s from initrd.\n", filename);
-      abort();
-    }
-
     {
       TransportData data;
-      data.SetEvalData(startup_file.Data(), startup_file.Size(), "__loader");
+      data.SetEvalData(reinterpret_cast<const uint8_t*>(LOADER_JS), sizeof(LOADER_JS) - 1, "__loader");
 
       std::unique_ptr<ThreadMessage> msg(new ThreadMessage(ThreadMessage::Type::EVALUATE,
                                          ResourceHandle<EngineThread>(), std::move(data)));

--- a/src/kernel/initjs.h
+++ b/src/kernel/initjs.h
@@ -16,7 +16,7 @@
 
 const char INIT_JS[] = R"JAVASCRIPT(
 // JS code to prepare runtime.js environment
-var console = (function() {
+global.console = (() => {
   var times = {};
 
   return {
@@ -37,5 +37,75 @@ var console = (function() {
     },
   };
 })();
-// No more code here
+
+(() => {
+  const promises = new WeakMap();
+  const setPromiseHandlers = __SYSCALL._setPromiseHandlers;
+  __SYSCALL._setPromiseHandlers = void 0;
+  let pendingTask = false;
+  let pendingPromises = [];
+
+  function rejected(promise, reason) {
+    if (promises.has(promise)) {
+      return;
+    }
+
+    promises.set(promise, false);
+    pendingPromises.push([promise, reason]);
+    setTask();
+  }
+
+  function rejectedHandled(promise) {
+    if (!promises.has(promise)) {
+      return;
+    }
+
+    const hasBeenNotified = promises.get(promise);
+    promises.delete(promise);
+
+    if (hasBeenNotified) {
+      if (typeof global.onrejectionhandled === 'function') {
+        setImmediate(() => global.onrejectionhandled({ promise }));
+      } else {
+        if (typeof global.onunhandledrejection !== 'function') {
+          console.log('Unhandled promise rejection has been handled.');
+        }
+      }
+    }
+  }
+
+  function setTask() {
+    if (pendingTask) {
+      return;
+    }
+
+    pendingTask = true;
+    setImmediate(() => {
+      pendingTask = false;
+
+      for (let i = 0; i < pendingPromises.length; ++i) {
+        let [promise, reason] = pendingPromises[i];
+        if (!promises.has(promise)) {
+          return;
+        }
+
+        promises.set(promise, true);
+
+        if (typeof global.onunhandledrejection === 'function') {
+          setImmediate(() => global.onunhandledrejection({ promise, reason }));
+        } else {
+          if (reason instanceof Error) {
+            console.log('Possibly unhandled promise rejection: ' + String(reason.stack));
+          } else {
+            console.log('Possibly unhandled promise rejection: ' + String(reason));
+          }
+        }
+      }
+
+      pendingPromises = [];
+    });
+  }
+
+  setPromiseHandlers(rejected, rejectedHandled);
+})();
 )JAVASCRIPT";

--- a/src/kernel/js/loaderjs.h
+++ b/src/kernel/js/loaderjs.h
@@ -1,0 +1,263 @@
+// Copyright 2014-2015 runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+const char LOADER_JS[] = R"JAVASCRIPT(
+'use strict';
+(() => {
+  function createLoader(existsFileFn, readFileFn, evalScriptFn, builtinsResolveFrom = '/') {
+    let builtins = {};
+    const builtinsResolveFromComponents = builtinsResolveFrom.split('/');
+    const cache = {};
+
+    function throwError(err) {
+      throw err;
+    }
+
+    function endsWith(str, suffix) {
+      return str.indexOf(suffix, str.length - suffix.length) !== -1;
+    }
+
+    function normalizePath(components) {
+      const r = [];
+      for (const p of components) {
+        if (p === '') {
+          if (r.length === 0) {
+            r.push(p);
+          }
+          continue;
+        }
+
+        if (p === '.') {
+          continue;
+        }
+
+        if (p === '..') {
+          if (r.length > 0) {
+            r.pop();
+          } else {
+            return null;
+          }
+        } else {
+          r.push(p);
+        }
+      }
+
+      return r;
+    }
+
+    function loadAsFile(path) {
+      if (existsFileFn(path)) return path;
+      if (existsFileFn(`${path}.js`)) return `${path}.js`;
+      if (existsFileFn(`${path}.json`)) return `${path}.json`;
+      if (existsFileFn(`${path}.node`)) return `${path}.node`;
+
+      return null;
+    }
+
+    function getPackageMain(packageJsonFile) {
+      const json = readFileFn(packageJsonFile);
+      let parsed = null;
+      try {
+        parsed = JSON.parse(json);
+      } catch (e) {
+        throwError(new Error(`package.json '${packageJsonFile}' parse error`));
+      }
+
+      if (parsed.runtime) {
+        if (typeof parsed.runtime === 'string') {
+          return parsed.runtime;
+        }
+        throwError(new Error(`package.json '${packageJsonFile}' runtime field value is invalid`));
+      }
+
+      return parsed.main || 'index.js';
+    }
+
+    function loadAsDirectory(path, ignoreJson) {
+      let mainFile = 'index';
+      let dir = false;
+      if (!ignoreJson && existsFileFn(`${path}/package.json`)) {
+        mainFile = getPackageMain(`${path}/package.json`) || 'index';
+        dir = true;
+      }
+
+      const normalizedPath = normalizePath(path.split('/').concat(mainFile.split('/')));
+      if (!normalizedPath) {
+        return null;
+      }
+
+      const s = normalizedPath.join('/');
+      const res = loadAsFile(s);
+      if (res) {
+        return res;
+      }
+
+      if (dir) {
+        return loadAsDirectory(s, true);
+      }
+
+      return null;
+    }
+
+    function loadNodeModules(dirComponents, parts) {
+      let count = dirComponents.length;
+
+      while (count-- > 0) {
+        let p = dirComponents.slice(0, count + 1);
+        if (p.length === 0) {
+          continue;
+        }
+
+        if (p[p.length - 1] === 'node_modules') {
+          continue;
+        }
+
+        p.push('node_modules');
+        p = p.concat(parts);
+
+        const normalizedPath = normalizePath(p);
+        if (!normalizedPath) {
+          continue;
+        }
+
+        const s = normalizedPath.join('/');
+        const loadedPath = loadAsFile(s) || loadAsDirectory(s, false) || null;
+        if (loadedPath) {
+          return loadedPath;
+        }
+      }
+
+      return null;
+    }
+
+    function resolve(module, pathOpt = '') {
+      let path = String(pathOpt);
+
+      let resolveFrom = module.dirComponents;
+
+      if (Object.prototype.hasOwnProperty.call(builtins, path)) {
+        path = builtins[path];
+        resolveFrom = builtinsResolveFromComponents;
+      }
+
+      const pathComponents = path.split('/');
+      const firstPathComponent = pathComponents[0];
+
+      // starts with ./ ../  or /
+      if (firstPathComponent === '.' ||
+        firstPathComponent === '..' ||
+        firstPathComponent === '') {
+        const combinedPathComponents = (firstPathComponent === '') ?
+          pathComponents :
+          resolveFrom.concat(pathComponents);
+
+        const normalizedPath = normalizePath(combinedPathComponents);
+        if (!normalizedPath) {
+          return null;
+        }
+
+        const pathStr = normalizedPath.join('/');
+        const loadedPath = loadAsFile(pathStr) || loadAsDirectory(pathStr, false) || null;
+        return loadedPath;
+      }
+
+      return loadNodeModules(resolveFrom, pathComponents);
+    }
+
+    class Module {
+      constructor(pathComponents) {
+        this.dirComponents = pathComponents.slice(0, -1);
+        this.pathComponents = pathComponents;
+        this.filename = pathComponents.join('/');
+        this.dirname = this.dirComponents.length > 1 ? this.dirComponents.join('/') : '/';
+        this.exports = {};
+      }
+      require(path) {
+        let module = this;
+        const resolvedPath = resolve(module, path);
+        if (!resolvedPath) {
+          throwError(new Error(`Cannot resolve module '${path}' from '${module.filename}'`));
+        }
+
+        // eval file
+        const pathComponents = resolvedPath.split('/');
+        const displayPath = resolvedPath;
+        const cacheKey = pathComponents.join('/');
+        if (cache[cacheKey]) {
+          return cache[cacheKey].exports;
+        }
+
+        const currentModule = global.module;
+        module = new Module(pathComponents);
+        cache[cacheKey] = module;
+        global.module = module;
+
+        if (endsWith(resolvedPath, '.node')) {
+          throwError(new Error(`Native Node.js modules are not supported '${resolvedPath}'`));
+        }
+
+        const content = readFileFn(resolvedPath);
+        if (!content) throwError(new Error(`Cannot load module '${resolvedPath}'`));
+
+        if (endsWith(resolvedPath, '.json')) {
+          module.exports = JSON.parse(content);
+        } else {
+          /* eslint-disable max-len */
+          evalScriptFn(
+            `((require,exports,module,__filename,__dirname) => {${content}})(((m) => {return function(path){return m.require(path)}})(global.module),global.module.exports,global.module,global.module.filename,global.module.dirname)`,
+            displayPath);
+          /* eslint-enable max-len */
+        }
+
+        global.module = currentModule;
+        return module.exports;
+      }
+    }
+
+    return {
+      require(path) {
+        const rootModule = new Module(['', '']);
+        global.module = rootModule;
+        return rootModule.require(path);
+      },
+      setupBuiltins(newBuiltins) {
+        builtins = newBuiltins;
+      }
+    };
+  }
+  // end
+
+  const files = {};
+  for (const file of __SYSCALL.initrdListFiles()) {
+    files[file] = true;
+  }
+
+  function fileExists(path) {
+    return !!files[path];
+  }
+
+  const kernelImportPath = __SYSCALL.initrdGetKernelIndex();
+  const appImportPath = __SYSCALL.initrdGetAppIndex();
+  const runtimePackagePath = kernelImportPath.split('/').slice(0, -1).join('/');
+  const loader = createLoader(fileExists, __SYSCALL.initrdReadFile, __SYSCALL.eval, runtimePackagePath);
+  __SYSCALL.loaderSetupBuiltins = loader.setupBuiltins;
+
+  loader.require(kernelImportPath);
+  if (appImportPath) {
+    loader.require(appImportPath);
+  }
+})();
+)JAVASCRIPT";

--- a/src/kernel/logger.h
+++ b/src/kernel/logger.h
@@ -129,6 +129,10 @@ public:
     console_enabled_ = true;
   }
 
+  void DisableConsole() {
+    console_enabled_ = false;
+  }
+
   void DisableVideo() {
     video_enabled_ = false;
   }

--- a/src/kernel/native-object.h
+++ b/src/kernel/native-object.h
@@ -54,6 +54,7 @@ public:
   DECLARE_NATIVE(InitrdReadFileBuffer);// Read file from initrd filesystem into buffer
   DECLARE_NATIVE(InitrdListFiles);     // List all files on initrd filesystem
   DECLARE_NATIVE(InitrdGetKernelIndex);// Get kernel entry point file
+  DECLARE_NATIVE(InitrdGetAppIndex);   // Get application entry point path
 
   // runtime.js syscalls: Profiler, debug and system info
   DECLARE_NATIVE(StartProfiling);      // Start profiler
@@ -63,6 +64,12 @@ public:
   DECLARE_NATIVE(MemoryInfo);          // Get memory information
   DECLARE_NATIVE(SystemInfo);          // Get system information
   DECLARE_NATIVE(Reboot);              // Reboot system
+  DECLARE_NATIVE(Poweroff);            // Poweroff system
+  DECLARE_NATIVE(Exit);                // Exit (will reboot system by default)
+
+  // global event listeners
+  DECLARE_NATIVE(AddEventListener);    // global.addEventListener
+  DECLARE_NATIVE(RemoveEventListener); // global.removeEventListener
 
   // runtime.js syscalls: Low level system access
   DECLARE_NATIVE(BufferAddress);       // Get buffer physical address
@@ -71,6 +78,7 @@ public:
   DECLARE_NATIVE(GetSystemResources);  // Get low-level system resources
   DECLARE_NATIVE(StopVideoLog);        // Stop console redirection to display
   DECLARE_NATIVE(SetTime);             // Set time in V8 engine
+  DECLARE_NATIVE(SetPromiseHandlers);  // Setup internal promise handlers
 
   // runtime.js syscalls: ACPI control bindings
   DECLARE_NATIVE(AcpiGetPciDevices);   // Get list of PCI devices

--- a/src/kernel/template-cache.cc
+++ b/src/kernel/template-cache.cc
@@ -99,6 +99,7 @@ v8::Local<v8::Context> TemplateCache::NewContext() {
     SET_SYSCALL("initrdReadFileBuffer", NativesObject::InitrdReadFileBuffer);
     SET_SYSCALL("initrdListFiles", NativesObject::InitrdListFiles);
     SET_SYSCALL("initrdGetKernelIndex", NativesObject::InitrdGetKernelIndex);
+    SET_SYSCALL("initrdGetAppIndex", NativesObject::InitrdGetAppIndex);
 
     // Profiler, debug and system info
     SET_SYSCALL("startProfiling", NativesObject::StartProfiling);
@@ -108,6 +109,8 @@ v8::Local<v8::Context> TemplateCache::NewContext() {
     SET_SYSCALL("memoryInfo", NativesObject::MemoryInfo);
     SET_SYSCALL("systemInfo", NativesObject::SystemInfo);
     SET_SYSCALL("reboot", NativesObject::Reboot);
+    SET_SYSCALL("poweroff", NativesObject::Poweroff);
+    SET_SYSCALL("exit", NativesObject::Exit);
 
     // Low level system access
     SET_SYSCALL("bufferAddress", NativesObject::BufferAddress);
@@ -117,12 +120,17 @@ v8::Local<v8::Context> TemplateCache::NewContext() {
     SET_SYSCALL("stopVideoLog", NativesObject::StopVideoLog);
     SET_SYSCALL("setTime", NativesObject::SetTime);
 
+    // Temporary for init.js script
+    SET_SYSCALL("_setPromiseHandlers", NativesObject::SetPromiseHandlers);
+
     // ACPI control bindings
     SET_SYSCALL("acpiGetPciDevices", NativesObject::AcpiGetPciDevices);
     SET_SYSCALL("acpiSystemReset", NativesObject::AcpiSystemReset);
     SET_SYSCALL("acpiEnterSleepState", NativesObject::AcpiEnterSleepState);
-
 #undef SET_SYSCALL
+    syscall->Set(iv8_, "onexit", v8::Null(iv8_));
+    syscall->Set(iv8_, "onerror", v8::Null(iv8_));
+
     global->Set(iv8_, "__SYSCALL", syscall);
 
     // Global performance object
@@ -147,7 +155,6 @@ v8::Local<v8::Context> TemplateCache::NewContext() {
 
   RT_ASSERT(!init_script_.IsEmpty());
   init_script_.Get(iv8_)->BindToCurrentContext()->Run(context).ToLocalChecked();
-
   return scope.Escape(context);
 }
 

--- a/src/kernel/v8utils.h
+++ b/src/kernel/v8utils.h
@@ -115,6 +115,12 @@ public:
   inline static Thread* GetThread(const v8::FunctionCallbackInfo<v8::Value>& args) {
     return reinterpret_cast<Thread*>(args.GetIsolate()->GetData(0));
   }
+
+  inline static Thread* GetThreadFromIsolate(v8::Isolate* iv8) {
+    RT_ASSERT(iv8);
+    return reinterpret_cast<Thread*>(iv8->GetData(0));
+  }
+
   inline static bool ValidateArg(const v8::FunctionCallbackInfo<v8::Value>& args,
                                  int argnum, ArgType type) {
 
@@ -283,6 +289,10 @@ public:
 
   void Clear() {
     data_.clear();
+  }
+
+  uint32_t Size() const {
+    return data_.size();
   }
 private:
   std::vector<v8::UniquePersistent<T>> data_;


### PR DESCRIPTION
Setting up better infrastructure for tests. Those are low level kernel APIs.

- Moved common js loader into the kernel, `require()` would work without any scripts loaded from initrd. This is needed to run tests in the empty environment, without loading runtime.js core library.
- `__SYSCALL.onexit = function() {}` - function called when runtime.js is about to exit similar to `process.on('exit')` in Node. Restarts the system by default.
- `__SYSCALL.onerror = function(err) {}` - uncaught exception handler, triggers exit by default.
- `__SYSCALL.exit()` - force exit
- `__SYSCALL.poweroff()` - power off the system, will exit qemu/kvm. 

For example, this line will poweroff runtime.js when there is nothing else to do (no listeners and empty event loop) or in case of an error.
```js
__SYSCALL.onexit = __SYSCALL.poweroff;
```

Promise. Those are global to match browser APIs.
- `global.onunhandledrejection = function({ promise, reason }) {}` - similar to https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onunhandledrejection
- `global.onrejectionhandled = function({ promise }) {}` - similar to https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onrejectionhandled
- default handlers print to the console
```
Possibly unhandled promise rejection: Error: oops
    at /index.js:48:11
    at /index.js:97:3
    at Module.require (__loader:203:11)
    at Object.require (__loader:218:27)
    at __loader:242:10
    at __loader:246:3
Unhandled promise rejection has been handled.
```

Adding actual tests is in progress